### PR TITLE
Don't catch exceptions

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 module.exports = fn => val => {
 	const ret = () => val;
-	return Promise.resolve(val).then(fn).then(ret, ret);
+	return Promise.resolve(val).then(fn).then(ret);
 };
 
 module.exports.catch = fn => err => {

--- a/index.js
+++ b/index.js
@@ -7,5 +7,5 @@ module.exports = fn => val => {
 
 module.exports.catch = fn => err => {
 	const ret = () => Promise.reject(err);
-	return Promise.resolve(err).then(fn).then(ret, ret);
+	return Promise.resolve(err).then(fn).then(ret);
 };

--- a/readme.md
+++ b/readme.md
@@ -60,9 +60,7 @@ Returns a [thunk](https://en.m.wikipedia.org/wiki/Thunk) that returns a `Promise
 
 Type: `Function`
 
-Any return value is ignored.
-
-However, The exceptions thrown (if any) in `input` are relayed back to the original promise chain.
+Any return value is ignored. Exceptions thrown in `input` are relayed back to the original promise chain.
 
 If `input` returns a `Promise`, it will be awaited before passing through the original value.
 

--- a/readme.md
+++ b/readme.md
@@ -60,7 +60,9 @@ Returns a [thunk](https://en.m.wikipedia.org/wiki/Thunk) that returns a `Promise
 
 Type: `Function`
 
-Any return value or exception is ignored.
+Any return value is ignored.
+
+However, The exceptions thrown (if any) in `input` are relayed back to the original promise chain.
 
 If `input` returns a `Promise`, it will be awaited before passing through the original value.
 

--- a/test.js
+++ b/test.js
@@ -5,6 +5,7 @@ import m from './';
 
 const fixture = Symbol('unicorn');
 const fixtureErr = new Error('unicorn');
+const tapErr = new Error('tap error!');
 
 test('ignores tap value', async t => {
 	const val = await Promise.resolve(fixture)
@@ -16,13 +17,14 @@ test('ignores tap value', async t => {
 	t.is(val, fixture);
 });
 
-test('ignores tap error', async t => {
-	const val = await Promise.resolve(fixture)
+test('does not ignore tap error', async t => {
+	await Promise.resolve(fixture)
 		.then(m(() => {
-			throw new Error('ignored-err');
-		}));
-
-	t.is(val, fixture);
+			throw tapErr;
+		}))
+		.catch(err => {
+			t.is(err, tapErr);
+		});
 });
 
 test('waits for tap promise to resolve', async t => {

--- a/test.js
+++ b/test.js
@@ -48,15 +48,15 @@ test('catch - ignores tap value', async t => {
 		});
 });
 
-test('catch - ignores tap error', async t => {
+test('catch - does not ignore tap error', async t => {
 	t.plan(1);
 
 	await Promise.reject(fixtureErr)
 		.catch(m.catch(() => {
-			throw new Error('ignored-err');
+			throw tapErr;
 		}))
 		.catch(err => {
-			t.is(err, fixtureErr);
+			t.is(err, tapErr);
 		});
 });
 

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 import test from 'ava';
 import delay from 'delay';
 import timeSpan from 'time-span';
-import m from './';
+import m from '.';
 
 const fixture = Symbol('unicorn');
 const fixtureErr = new Error('unicorn');


### PR DESCRIPTION
`pTap` and `pTap.catch` methods do not ignore errors thrown in tap callbacks anymore.

Fixes #3 